### PR TITLE
Minor Functionality Additions

### DIFF
--- a/tbx/+ads/+fe/Beam.m
+++ b/tbx/+ads/+fe/Beam.m
@@ -187,6 +187,23 @@ classdef Beam < ads.fe.Element
 
 
         end
+
+        function order = getEtaOrder(obj)
+            % order is an array the same length as obj. order(i) gives the index of the ith beam element in order of
+            % ascending eta from the wing root. So if order(4) = j then obj(j) is the 4th beam element from the root. The
+            % starting eta of each element is used to conduct the sorting operation.
+            % you can use this output to get anything you like from fe.beams in eta order, e.g. EIDs = [fe.beams(order).ID] 
+
+            % get the start eta of each beam
+            wingStations = [obj.Stations];
+            startEtas = [wingStations(1,:).eta];
+            
+            % get the sorting order
+            [~, order] = sort(startEtas);
+
+
+        end
+
         %%%%%%%% END %%%%%%%%
     end
     methods(Static)

--- a/tbx/+ads/+fe/Beam.m
+++ b/tbx/+ads/+fe/Beam.m
@@ -143,9 +143,8 @@ classdef Beam < ads.fe.Element
             end
         end
 
-        %% Added by Ed
         function EIDs = EIDfromEta(obj, eta)
-            % function to return the Element IDs (EIDs) of the beam element s containing the baff beam station eta. EIDs is a
+            % function to return the Element ID(s) (EIDs) of the beam element(s) containing the baff beam station(S) eta. EIDs is a
             % 2xN array where N is the length of eta. For a given column of EIDs, the two rows are identical UNLESS eta lies
             % exactly on a GRID (i.e. an element boundary). In this case, the first row contains the INBD element, and the
             % second row the OUTBD one. 
@@ -204,7 +203,6 @@ classdef Beam < ads.fe.Element
 
         end
 
-        %%%%%%%% END %%%%%%%%
     end
     methods(Static)
         function obj = Bar(PointA,PointB,height,width,Material)

--- a/tbx/+ads/+fe/BeamStation.m
+++ b/tbx/+ads/+fe/BeamStation.m
@@ -8,6 +8,7 @@ classdef BeamStation
         I = eye(3);
         J = 1;
         Mat ads.fe.Material = ads.fe.Material.Aluminium;
+        eta = NaN;
     end
     methods
         function obj = BeamStation(Point,opts)
@@ -59,6 +60,11 @@ classdef BeamStation
                 Mat ads.fe.Material
             end
             obj = ads.fe.BeamStation(p,"A",st.A,"I",st.I,"J",st.J,"Mat",Mat);
+
+            %%% Added by Ed %%%
+            obj.eta = st.Eta;
+            %%%%%%% END %%%%%%%
+
         end
     end
 end

--- a/tbx/+ads/+fe/BeamStation.m
+++ b/tbx/+ads/+fe/BeamStation.m
@@ -8,8 +8,8 @@ classdef BeamStation
         I = eye(3);
         J = 1;
         Mat ads.fe.Material = ads.fe.Material.Aluminium;
-        eta = NaN;
-        % EDW  - Added properties to carry around stress recovery points. As you would expect, these are the [1,2]
+        eta = NaN;  % Add this so we can easily keep track of where an ads element was in a BAFF wing.
+        % Added properties to carry around stress recovery points. As you would expect, these are the [1,2]
         % coordinates of the C, D E and F recovery points as per the NASTRAN PBEAM docs. The arc length information comes
         % from the rest of the station definition.
         C (2,1) double = [nan;nan];
@@ -26,7 +26,6 @@ classdef BeamStation
                 opts.I = eye(3);
                 opts.J = 1;
                 opts.Izz = 1;
-                % EDW - also added recovery points to constructor method
                 opts.C = [nan;nan];
                 opts.D = [nan;nan];
                 opts.E = [nan;nan];
@@ -45,8 +44,9 @@ classdef BeamStation
         function matSec = ToMatranSection(obj,startPoint,endPoint)
             eta = dot(endPoint-startPoint,obj.Point.X-startPoint)/norm(endPoint-startPoint).^2;
             eta = round(eta,10); % sometimes numerical rounding errors make a 1 not a one...
-            % EDW - also pass the recovery point coordinates. These are NaN by default in the matran BeamSection class, so it
-            % doesn't matter if the user didn't specify them (since they're NaN by default in this class too).
+            % Sow updated to also pass the recovery point coordinates. These are NaN by default in the matran BeamSection 
+            % class, so it doesn't matter if the user didn't specify them in this class (since they're NaN by default here 
+            % too).
             matSec = mni.printing.cards.BeamSection(obj.A, obj.I(3,3), obj.I(2,2), 0, obj.J, eta, C=obj.C, D=obj.D, E=obj.E, F=obj.F);
         end
     end
@@ -76,7 +76,7 @@ classdef BeamStation
                 st baff.station.Beam
                 p ads.fe.Point
                 Mat ads.fe.Material
-                % EDW - also added recovery points to the de facto constructor method
+                % added recovery points as an option here in case we ever want to specify them in BAFF...
                 opts.C = [nan;nan];
                 opts.D = [nan;nan];
                 opts.E = [nan;nan];
@@ -84,10 +84,7 @@ classdef BeamStation
             end
             obj = ads.fe.BeamStation(p,"A",st.A,"I",st.I,"J",st.J,"Mat",Mat, ...
                                                 "C", opts.C, "D", opts.D, "E", opts.E, "F", opts.F);
-
-            %%% Added by Ed %%%
             obj.eta = st.Eta;
-            %%%%%%% END %%%%%%%
 
         end
     end

--- a/tbx/+ads/+fe/BeamStation.m
+++ b/tbx/+ads/+fe/BeamStation.m
@@ -9,6 +9,13 @@ classdef BeamStation
         J = 1;
         Mat ads.fe.Material = ads.fe.Material.Aluminium;
         eta = NaN;
+        % EDW  - Added properties to carry around stress recovery points. As you would expect, these are the [1,2]
+        % coordinates of the C, D E and F recovery points as per the NASTRAN PBEAM docs. The arc length information comes
+        % from the rest of the station definition.
+        C (2,1) double = [nan;nan];
+        D (2,1) double = [nan;nan];
+        E (2,1) double = [nan;nan];
+        F (2,1) double = [nan;nan];
     end
     methods
         function obj = BeamStation(Point,opts)
@@ -19,17 +26,28 @@ classdef BeamStation
                 opts.I = eye(3);
                 opts.J = 1;
                 opts.Izz = 1;
+                % EDW - also added recovery points to constructor method
+                opts.C = [nan;nan];
+                opts.D = [nan;nan];
+                opts.E = [nan;nan];
+                opts.F = [nan;nan];
             end
             obj.Point = Point;
             obj.A = opts.A;
             obj.Mat = opts.Mat;
             obj.I = opts.I;
             obj.J = opts.J;
+            obj.C = opts.C;
+            obj.D = opts.D;
+            obj.E = opts.E;
+            obj.F = opts.F;  
         end
         function matSec = ToMatranSection(obj,startPoint,endPoint)
             eta = dot(endPoint-startPoint,obj.Point.X-startPoint)/norm(endPoint-startPoint).^2;
             eta = round(eta,10); % sometimes numerical rounding errors make a 1 not a one...
-            matSec = mni.printing.cards.BeamSection(obj.A,obj.I(3,3),obj.I(2,2),0,obj.J,eta);
+            % EDW - also pass the recovery point coordinates. These are NaN by default in the matran BeamSection class, so it
+            % doesn't matter if the user didn't specify them (since they're NaN by default in this class too).
+            matSec = mni.printing.cards.BeamSection(obj.A, obj.I(3,3), obj.I(2,2), 0, obj.J, eta, C=obj.C, D=obj.D, E=obj.E, F=obj.F);
         end
     end
     methods(Static)
@@ -53,13 +71,19 @@ classdef BeamStation
             J = a*b^3*(1/3-0.2085*(b/a)*(1-(b^4)/(12*a^4)));
             obj = ads.fe.BeamStation(Point,I=I,A=height*width, J=J, Mat=opts.Mat);
         end
-        function obj = FromBaffStation(st,p,Mat)
+        function obj = FromBaffStation(st,p,Mat, opts)
             arguments
                 st baff.station.Beam
                 p ads.fe.Point
                 Mat ads.fe.Material
+                % EDW - also added recovery points to the de facto constructor method
+                opts.C = [nan;nan];
+                opts.D = [nan;nan];
+                opts.E = [nan;nan];
+                opts.F = [nan;nan];
             end
-            obj = ads.fe.BeamStation(p,"A",st.A,"I",st.I,"J",st.J,"Mat",Mat);
+            obj = ads.fe.BeamStation(p,"A",st.A,"I",st.I,"J",st.J,"Mat",Mat, ...
+                                                "C", opts.C, "D", opts.D, "E", opts.E, "F", opts.F);
 
             %%% Added by Ed %%%
             obj.eta = st.Eta;

--- a/tbx/+ads/+fe/Point.m
+++ b/tbx/+ads/+fe/Point.m
@@ -69,6 +69,32 @@ classdef Point   < matlab.mixin.SetGet & ads.fe.Element
                 end
             end
         end
+
+        %% Added by Ed
+
+        function GIDs = GRIDfromEta(obj, baffStation, eta)
+            % Return the ads.fe point ID closest to eta. baffStation must be the baff.
+            arguments
+                obj
+                baffStation baff.station.Beam
+                eta
+            end
+
+            % compute the position of eta in the 'X' system, whatever that is. Will assume eta refers to a point on the spar
+            pos = baffStation.GetPos(eta);
+            numQueries  = length(eta);
+
+            % compute the smallest distance to all points in the current object array
+            minDices = zeros(1,numQueries);
+            for i = 1:numQueries
+                deltas = [obj.X] - pos(:,i);
+                dists = vecnorm(deltas,2,1);
+                [~, minDices(i)] = min(dists, [], 2);
+            end
+
+            GIDs = [obj(minDices).ID];
+
+        end
     end
 end
 

--- a/tbx/+ads/+fe/Point.m
+++ b/tbx/+ads/+fe/Point.m
@@ -70,17 +70,15 @@ classdef Point   < matlab.mixin.SetGet & ads.fe.Element
             end
         end
 
-        %% Added by Ed
-
         function GIDs = GRIDfromEta(obj, baffStation, eta)
-            % Return the ads.fe point ID closest to eta. baffStation must be the baff.
+            % Return the ads.fe point ID closest to eta.
             arguments
                 obj
                 baffStation baff.station.Beam
-                eta
+                eta double
             end
 
-            % compute the position of eta in the 'X' system, whatever that is. Will assume eta refers to a point on the spar
+            % compute the position of eta in the 'X' system. Will assume eta refers to a point on the spar
             pos = baffStation.GetPos(eta);
             numQueries  = length(eta);
 

--- a/tbx/+ads/+nast/@Sol103/Sol103.m
+++ b/tbx/+ads/+nast/@Sol103/Sol103.m
@@ -37,6 +37,20 @@ classdef Sol103 < handle
         function str = config_string(obj)
             str = '';
         end
+
+
+        %% EDW: add a method to write a .bat file to the same location as the main .bdf. 
+        % This .bat will run the analysis and make NASTRAN write the result to the appropriate .bin folder
+        function writeJobSubmissionBat(~, binFolder)
+            batFile = fullfile(pwd, binFolder, 'Source', 'run103.bat');
+            fid = fopen(batFile,'w');
+            fprintf(fid, '%s \n', 'nastran sol103.bdf out=..\bin\');
+            fclose(fid);
+        end
+        %%%%%%% END %%%%%%%%%
+    
+
     end
+
 end
 

--- a/tbx/+ads/+nast/@Sol103/Sol103.m
+++ b/tbx/+ads/+nast/@Sol103/Sol103.m
@@ -39,16 +39,15 @@ classdef Sol103 < handle
         end
 
 
-        %% EDW: add a method to write a .bat file to the same location as the main .bdf. 
-        % This .bat will run the analysis and make NASTRAN write the result to the appropriate .bin folder
+        %% A method to write a .bat file to the same location as the main .bdf which will run the analysis and make NASTRAN 
+        % write the result to the appropriate bin folder. This is just a convenience if you want to run the analysis without
+        % going via MATLAB.
         function writeJobSubmissionBat(~, binFolder)
             batFile = fullfile(pwd, binFolder, 'Source', 'run103.bat');
             fid = fopen(batFile,'w');
             fprintf(fid, '%s \n', 'nastran sol103.bdf out=..\bin\');
             fclose(fid);
-        end
-        %%%%%%% END %%%%%%%%%
-    
+        end    
 
     end
 

--- a/tbx/+ads/+nast/@Sol103/run.m
+++ b/tbx/+ads/+nast/@Sol103/run.m
@@ -7,6 +7,9 @@ arguments
     opts.NumAttempts = 3;
     opts.BinFolder string = '';
     opts.IncludeEigenVec = true;
+
+    % EDW: add option to create a batch file
+    opts.createBat = false;
 end
 
 %% create BDFs
@@ -36,6 +39,12 @@ end
 %create main BDF file
 bdfFile = fullfile(pwd,binFolder,'Source','sol103.bdf');
 obj.write_main_bdf(bdfFile,[modelFile]);
+
+% EDW: write the bat file if we were asked
+if opts.createBat
+    obj.writeJobSubmissionBat(binFolder);
+end
+%%%%% END %%%%%%
 
 %% Run Analysis
 attempt = 1;

--- a/tbx/+ads/+nast/@Sol103/run.m
+++ b/tbx/+ads/+nast/@Sol103/run.m
@@ -7,8 +7,6 @@ arguments
     opts.NumAttempts = 3;
     opts.BinFolder string = '';
     opts.IncludeEigenVec = true;
-
-    % EDW: add option to create a batch file
     opts.createBat = false;
 end
 
@@ -40,11 +38,10 @@ end
 bdfFile = fullfile(pwd,binFolder,'Source','sol103.bdf');
 obj.write_main_bdf(bdfFile,[modelFile]);
 
-% EDW: write the bat file if we were asked
+% write the batch file if we were asked
 if opts.createBat
     obj.writeJobSubmissionBat(binFolder);
 end
-%%%%% END %%%%%%
 
 %% Run Analysis
 attempt = 1;

--- a/tbx/+ads/+nast/@Sol144/Sol144.m
+++ b/tbx/+ads/+nast/@Sol144/Sol144.m
@@ -46,7 +46,7 @@ classdef Sol144 < handle
         Load_ID = 5;
         SPCs = [];
         ForceIDs = [];
-        StressIDs = [];     % EDW: added to mirror the functionality of the sol146 class
+        StressIDs = [];     % added to mirror the functionality of the sol146 class
 
         %CoM and constraint Paramters
         g = 9.81;
@@ -95,15 +95,15 @@ classdef Sol144 < handle
             obj.DoFs = [];
         end
         
-        %% EDW: add a method to write a .bat file to the same location as the main .bdf. 
-        % This .bat will run the analysis and make NASTRAN write the result to the appropriate .bin folder
+        %% A method to write a .bat file to the same location as the main .bdf which will run the analysis and make NASTRAN 
+        % write the result to the appropriate bin folder. This is just a convenience if you want to run the analysis without
+        % going via MATLAB.
         function writeJobSubmissionBat(~, binFolder)
             batFile = fullfile(pwd, binFolder, 'Source', 'run144.bat');
             fid = fopen(batFile,'w');
             fprintf(fid, '%s \n', 'nastran sol144.bdf out=..\bin\');
             fclose(fid);
         end
-        %%%%%%% END %%%%%%%%%
     end
 end
 

--- a/tbx/+ads/+nast/@Sol144/Sol144.m
+++ b/tbx/+ads/+nast/@Sol144/Sol144.m
@@ -94,6 +94,16 @@ classdef Sol144 < handle
             obj.ANGLEA.Value = 0;
             obj.DoFs = [];
         end
+        
+        %% EDW: add a method to write a .bat file to the same location as the main .bdf. 
+        % This .bat will run the analysis and make NASTRAN write the result to the appropriate .bin folder
+        function writeJobSubmissionBat(~, binFolder)
+            batFile = fullfile(pwd, binFolder, 'Source', 'run144.bat');
+            fid = fopen(batFile,'w');
+            fprintf(fid, '%s \n', 'nastran sol144.bdf out=..\bin\');
+            fclose(fid);
+        end
+        %%%%%%% END %%%%%%%%%
     end
 end
 

--- a/tbx/+ads/+nast/@Sol144/Sol144.m
+++ b/tbx/+ads/+nast/@Sol144/Sol144.m
@@ -46,6 +46,7 @@ classdef Sol144 < handle
         Load_ID = 5;
         SPCs = [];
         ForceIDs = [];
+        StressIDs = [];     % EDW: added to mirror the functionality of the sol146 class
 
         %CoM and constraint Paramters
         g = 9.81;

--- a/tbx/+ads/+nast/@Sol144/run.m
+++ b/tbx/+ads/+nast/@Sol144/run.m
@@ -10,8 +10,6 @@ arguments
     opts.trimObjs = ads.nast.TrimParameter.empty;
     opts.OutputAeroMatrices logical = false;
     opts.UseHdf5 = true;
-
-    % EDW: add option to create a batch file
     opts.createBat = false;
 end
 obj.OutputAeroMatrices = opts.OutputAeroMatrices;
@@ -61,11 +59,10 @@ end
 bdfFile = fullfile(pwd,binFolder,'Source','sol144.bdf');
 obj.write_main_bdf(bdfFile,[modelFile,trimFile]);
 
-% EDW: write the bat file if we were asked
+% write the batch file if we were asked
 if opts.createBat
     obj.writeJobSubmissionBat(binFolder);
 end
-%%%%% END %%%%%%
 
 %% Run Analysis
 attempt = 1;

--- a/tbx/+ads/+nast/@Sol144/run.m
+++ b/tbx/+ads/+nast/@Sol144/run.m
@@ -10,6 +10,9 @@ arguments
     opts.trimObjs = ads.nast.TrimParameter.empty;
     opts.OutputAeroMatrices logical = false;
     opts.UseHdf5 = true;
+
+    % EDW: add option to create a batch file
+    opts.createBat = false;
 end
 obj.OutputAeroMatrices = opts.OutputAeroMatrices;
 %% create BDFs
@@ -57,6 +60,12 @@ end
 %create main BDF file
 bdfFile = fullfile(pwd,binFolder,'Source','sol144.bdf');
 obj.write_main_bdf(bdfFile,[modelFile,trimFile]);
+
+% EDW: write the bat file if we were asked
+if opts.createBat
+    obj.writeJobSubmissionBat(binFolder);
+end
+%%%%% END %%%%%%
 
 %% Run Analysis
 attempt = 1;

--- a/tbx/+ads/+nast/@Sol144/write_main_bdf.m
+++ b/tbx/+ads/+nast/@Sol144/write_main_bdf.m
@@ -38,8 +38,23 @@ end
     fprintf(fid,'LOAD=%.0f\n',obj.Load_ID);
     println(fid,'MONITOR = ALL');
     println(fid,'SPCFORCES = ALL');
-    println(fid,'FORCE(SORT1,REAL) = ALL');
-    println(fid,'DISPLACEMENT(SORT1,REAL)=ALL');
+    println(fid,'FORCE(SORT1,REAL) = ALL');         % EDW - leave this as is: sol144.run seems to have some additional functionality which utilises the forceIDs object in a different way to sol146 
+    println(fid,'DISPLACEMENT(SORT1,REAL)=ALL');    % EDW - Again, leave this alone. The f06 is less expensive to write and store in a 144 anyway
+
+    %% added by Ed to mirror functionality of the sol146 class
+    % request stresses
+    if ~isempty(obj.StressIDs)
+        if any(isnan(obj.StressIDs))
+            println(fid,'STRESS(SORT1,REAL)= NONE');
+        else
+            mni.printing.cases.SET(3,obj.StressIDs).writeToFile(fid);
+            println(fid,'STRESS(SORT1,REAL)= 3');
+        end
+    else
+        println(fid,'STRESS(SORT1,REAL)= ALL');
+    end
+    %%%%%%%%%%% END %%%%%%%%%%
+    
     println(fid,'GROUNDCHECK=YES');
     println(fid,'AEROF=ALL');
     println(fid,'APRES=ALL');

--- a/tbx/+ads/+nast/@Sol144/write_main_bdf.m
+++ b/tbx/+ads/+nast/@Sol144/write_main_bdf.m
@@ -39,9 +39,8 @@ end
     println(fid,'MONITOR = ALL');
     println(fid,'SPCFORCES = ALL');
     println(fid,'FORCE(SORT1,REAL) = ALL');         % EDW - leave this as is: sol144.run seems to have some additional functionality which utilises the forceIDs object in a different way to sol146 
-    println(fid,'DISPLACEMENT(SORT1,REAL)=ALL');    % EDW - Again, leave this alone. The f06 is less expensive to write and store in a 144 anyway
+    println(fid,'DISPLACEMENT(SORT1,REAL)=ALL');    % EDW - Again, leave this alone.
 
-    %% added by Ed to mirror functionality of the sol146 class
     % request stresses
     if ~isempty(obj.StressIDs)
         if any(isnan(obj.StressIDs))
@@ -53,7 +52,6 @@ end
     else
         println(fid,'STRESS(SORT1,REAL)= ALL');
     end
-    %%%%%%%%%%% END %%%%%%%%%%
     
     println(fid,'GROUNDCHECK=YES');
     println(fid,'AEROF=ALL');

--- a/tbx/+ads/+nast/@Sol146/Sol146.m
+++ b/tbx/+ads/+nast/@Sol146/Sol146.m
@@ -27,6 +27,7 @@ classdef Sol146 < handle
 
         DispIDs = [];
         ForceIDs = [];
+        StressIDs = [];     % EDW: added to mirror the functionality for displacement and force.
 
         % gust data
         Gusts = ads.nast.gust.BaseSettings.empty;

--- a/tbx/+ads/+nast/@Sol146/Sol146.m
+++ b/tbx/+ads/+nast/@Sol146/Sol146.m
@@ -27,7 +27,7 @@ classdef Sol146 < handle
 
         DispIDs = [];
         ForceIDs = [];
-        StressIDs = [];     % EDW: added to mirror the functionality for displacement and force.
+        StressIDs = [];     % added to mirror the functionality for displacement and force.
 
         % gust data
         Gusts = ads.nast.gust.BaseSettings.empty;
@@ -96,15 +96,15 @@ classdef Sol146 < handle
             str = '';
         end
         
-        %% EDW: add a method to write a .bat file to the same location as the main .bdf. 
-        % This .bat will run the analysis and make NASTRAN write the result to the appropriate .bin folder
+        %% A method to write a .bat file to the same location as the main .bdf which will run the analysis and make NASTRAN 
+        % write the result to the appropriate .bin folder. This is just a convenience if you want to run the analysis without
+        % going via MATLAB.
         function writeJobSubmissionBat(~, binFolder)
             batFile = fullfile(pwd, binFolder, 'Source', 'run146.bat');
             fid = fopen(batFile,'w');
             fprintf(fid, '%s \n', 'nastran sol146.bdf out=..\bin\');
             fclose(fid);
         end
-        %%%%%%% END %%%%%%%%%
 
     end
 end

--- a/tbx/+ads/+nast/@Sol146/Sol146.m
+++ b/tbx/+ads/+nast/@Sol146/Sol146.m
@@ -95,6 +95,17 @@ classdef Sol146 < handle
         function str = config_string(obj)
             str = '';
         end
+        
+        %% EDW: add a method to write a .bat file to the same location as the main .bdf. 
+        % This .bat will run the analysis and make NASTRAN write the result to the appropriate .bin folder
+        function writeJobSubmissionBat(~, binFolder)
+            batFile = fullfile(pwd, binFolder, 'Source', 'run146.bat');
+            fid = fopen(batFile,'w');
+            fprintf(fid, '%s \n', 'nastran sol146.bdf out=..\bin\');
+            fclose(fid);
+        end
+        %%%%%%% END %%%%%%%%%
+
     end
 end
 

--- a/tbx/+ads/+nast/@Sol146/run.m
+++ b/tbx/+ads/+nast/@Sol146/run.m
@@ -7,6 +7,9 @@ arguments
     opts.NumAttempts = 1;
     opts.BinFolder string = '';
     opts.TruelySilent = false;
+
+    % EDW: add option to create a batch file
+    opts.createBat = false;
 end
 
 %% create BDFs
@@ -43,6 +46,12 @@ end
 %create main BDF file
 bdfFile = fullfile(pwd,binFolder,'Source','sol146.bdf');
 obj.write_main_bdf(bdfFile,[modelFile,gustFile]);
+
+% EDW: write the bat file if we were asked
+if opts.createBat
+    obj.writeJobSubmissionBat(binFolder);
+end
+%%%%% END %%%%%%
 
 %% Run Analysis
 attempt = 1;

--- a/tbx/+ads/+nast/@Sol146/run.m
+++ b/tbx/+ads/+nast/@Sol146/run.m
@@ -47,11 +47,10 @@ end
 bdfFile = fullfile(pwd,binFolder,'Source','sol146.bdf');
 obj.write_main_bdf(bdfFile,[modelFile,gustFile]);
 
-% EDW: write the bat file if we were asked
+% write the batch file if we were asked
 if opts.createBat
     obj.writeJobSubmissionBat(binFolder);
 end
-%%%%% END %%%%%%
 
 %% Run Analysis
 attempt = 1;

--- a/tbx/+ads/+nast/@Sol146/write_main_bdf.m
+++ b/tbx/+ads/+nast/@Sol146/write_main_bdf.m
@@ -48,6 +48,19 @@ end
     else
         println(fid,'FORCE(SORT1,REAL)= ALL');
     end
+    % EDW: added the below block to print stresses if required. Could do similar for strain if you create a reader function
+    % to go with it, but just dividing the stresses by E in post seemed altoghther less faff...
+    if ~isempty(obj.StressIDs)
+        if any(isnan(obj.StressIDs))
+            println(fid,'STRESS(SORT1,REAL)= NONE');
+        else
+            mni.printing.cases.SET(3,obj.StressIDs).writeToFile(fid);
+            println(fid,'STRESS(SORT1,REAL)= 3');
+        end
+    else
+        println(fid,'STRESS(SORT1,REAL)= ALL');
+    end
+    %%%%%%%%%%%%%% END %%%%%%%%%%%%
     println(fid,'MONITOR = ALL');    
     
     % write gust subcases


### PR DESCRIPTION
I have made a number of small changes to add some functionality I wanted:

- `fe.Point` and `fe.Beam` now have methods to get a node/element ID from an eta point in their corresponding baff model (if one exists).
- `fe.Beam` also now has a method to compute the 'wing order' of its elements, meaning they can be sorted in order of span. This may be irrelevant if `baff2fe()` always numbers elements in eta order, but I didn't want to rely on that...
- Properties added to `fe.BeamStation` corresponding the four stress recovery points allowed by a NASTRAN PBEAM. The `ToMatranSection()` method now sends these points to the matran PBEAM card printer class.
- Added the option to request stress output to `Sol144` and `Sol146,` mirroring existing functionality for displacement and force.
- Modified the `Sol146` bdf writer so it requests PSDF output if any gusts are turbulence cases.
- Added a method to each of `Sol103`, `Sol144` and `Sol146` which writes a batch file capable of submitting the job independently of MATLAB. This was basically me being lazy and not wanting to type out the full command sending output to the bin folder every time!